### PR TITLE
Script changes to fix reproducibility

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -11,12 +11,14 @@ vul4j verify --id VUL4J-1 VUL4J-2 VUL4J-3 VUL4J-4 VUL4J-5 VUL4J-6 VUL4J-7 VUL4J-
 
 * (\*) Some project versions are not *fully compilable*, however, the modules that contain the target vulnerabilities and their PoVs are compilable. Therefore, the vulnerabilities are *reproducible*. These cases are indicated with a yellow circle (🟡).
 
+* Some projects needed manual modifications in order to be reproducible (dependency changes, other fixes from later commits). The vul4j script cannot automatically replace or change all of these files, so manual intervention is needed. These cases are indicated with a hand (🖐).
+
 | Vuln ID   | Compilable | PoV(s) | Reproducible |
 |-----------|:------:|:------:|:-------:|
 | VUL4J-1	|	✅	|	✅	| 	✅	|
 | VUL4J-2	|	✅	|	✅	| 	✅	|
-| VUL4J-3	|	❌	|	✅	| 	🟡	|
-| VUL4J-4	|	❌	|	✅	| 	🟡	|
+| VUL4J-3	|	✅	|	✅	| 	✅	|
+| VUL4J-4	|	✅	|	✅	| 	✅	|
 | VUL4J-5	|	✅	|	✅	| 	✅	|
 | VUL4J-6	|	✅	|	✅	| 	✅	|
 | VUL4J-7	|	✅	|	✅	| 	✅	|
@@ -27,27 +29,27 @@ vul4j verify --id VUL4J-1 VUL4J-2 VUL4J-3 VUL4J-4 VUL4J-5 VUL4J-6 VUL4J-7 VUL4J-
 | VUL4J-12	|	✅	|	✅	| 	✅	|
 | VUL4J-13	|	✅	|	✅	| 	✅	|
 | VUL4J-14	|	✅	|	✅	| 	✅	|
-| VUL4J-15	|	❌	|	✅	| 	🟡	|
+| VUL4J-15	|	❌	|	✅	| 	🟡	 |
 | VUL4J-16	|	✅	|	✅	| 	✅	|
 | VUL4J-17	|	✅	|	✅	| 	✅	|
 | VUL4J-18	|	✅	|	✅	| 	✅	|
 | VUL4J-19	|	✅	|	✅	| 	✅	|
 | VUL4J-20	|	✅	|	✅	| 	✅	|
-| VUL4J-21	|	✅	|	❌	| 	❌	|
+| VUL4J-21	|	✅	|	✅	| 	✅	|
 | VUL4J-22	|	✅	|	✅	| 	✅	|
-| VUL4J-23	|	❌	|	✅	| 	🟡	|
+| VUL4J-23	|	🖐 	 |	 ✅	 | 	 🖐	  |
 | VUL4J-24	|	✅	|	✅	| 	✅	|
 | VUL4J-25	|	✅	|	✅	| 	✅	|
 | VUL4J-26	|	✅	|	✅	| 	✅	|
-| VUL4J-27	|	❌	|	✅	| 	🟡	|
-| VUL4J-28	|	❌	|	❌	| 	❌	|
+| VUL4J-27	|	✅	|	✅	| 	✅	|
+| VUL4J-28	|	✅	|	✅	| 	✅	|
 | VUL4J-29	|	✅	|	✅	| 	✅	|
 | VUL4J-30	|	✅	|	✅	| 	✅	|
-| VUL4J-31	|	❌	|	❌	| 	❌	|
+| VUL4J-31	|	✅	|	✅	| 	✅	|
 | VUL4J-32	|	✅	|	✅	| 	✅	|
 | VUL4J-33	|	✅	|	✅	| 	✅	|
 | VUL4J-34	|	✅	|	✅	| 	✅	|
-| VUL4J-35	|	❌	|	✅	| 	🟡	|
+| VUL4J-35	|	🖐   |	 ✅	 | 	 🖐	  |
 | VUL4J-36	|	✅	|	✅	| 	✅	|
 | VUL4J-37	|	✅	|	✅	| 	✅	|
 | VUL4J-38	|	✅	|	✅	| 	✅	|
@@ -66,7 +68,7 @@ vul4j verify --id VUL4J-1 VUL4J-2 VUL4J-3 VUL4J-4 VUL4J-5 VUL4J-6 VUL4J-7 VUL4J-
 | VUL4J-51	|	❌	|	❌	| 	❌	|
 | VUL4J-52	|	✅	|	✅	| 	✅	|
 | VUL4J-53	|	✅	|	✅	| 	✅	|
-| VUL4J-54	|	✅	|	❌	| 	❌	|
+| VUL4J-54	|	✅	|	✅	| 	✅	|
 | VUL4J-55	|	✅	|	✅	| 	✅	|
 | VUL4J-56	|	✅	|	✅	| 	✅	|
 | VUL4J-57	|	✅	|	✅	| 	✅	|
@@ -76,17 +78,17 @@ vul4j verify --id VUL4J-1 VUL4J-2 VUL4J-3 VUL4J-4 VUL4J-5 VUL4J-6 VUL4J-7 VUL4J-
 | VUL4J-61	|	✅	|	✅	| 	✅	|
 | VUL4J-62	|	✅	|	✅	| 	✅	|
 | VUL4J-63	|	✅	|	✅	| 	✅	|
-| VUL4J-64	|	❌	|	❌	| 	❌	|
-| VUL4J-65	|	❌	|	❌	| 	❌	|
+| VUL4J-64	|	✅	|	✅	| 	✅	|
+| VUL4J-65	|	✅	|	✅	| 	✅	|
 | VUL4J-66	|	✅	|	✅	| 	✅	|
-| VUL4J-67	|	❌	|	❌	| 	❌	|
-| VUL4J-68	|	❌	|	❌	| 	❌	|
-| VUL4J-69	|	❌	|	❌	| 	❌	|
-| VUL4J-70	|	❌	|	❌	| 	❌	|
-| VUL4J-71	|	❌	|	❌	| 	❌	|
-| VUL4J-72	|	❌	|	❌	| 	❌	|
-| VUL4J-73	|	❌	|	❌	| 	❌	|
-| VUL4J-74	|	❌	|	❌	| 	❌	|
+| VUL4J-67	|	🖐	 |	 🖐	  |   🖐   |
+| VUL4J-68	|	✅	|	✅	| 	✅	|
+| VUL4J-69	|	✅	|	✅	| 	✅	|
+| VUL4J-70	|	✅	|	✅	| 	✅	|
+| VUL4J-71	|	🖐	 |	 🖐	  |   🖐   |
+| VUL4J-72	|	✅	|	✅	| 	✅	|
+| VUL4J-73	|	✅	|	✅	| 	✅	|
+| VUL4J-74	|	✅	|	✅	| 	✅	|
 | VUL4J-75	|	✅	|	✅	| 	✅	|
 | VUL4J-76	|	✅	|	✅	| 	✅	|
 | VUL4J-77	|	✅	|	✅	| 	✅	|

--- a/vul4j/config.py
+++ b/vul4j/config.py
@@ -20,3 +20,5 @@ MVN_OPTS = os.environ.get("MVN_OPTS", "-Xmx4g -Xms1g -XX:MaxPermSize=512m")
 
 OUTPUT_FOLDER_NAME = "VUL4J"
 ENABLE_EXECUTING_LOGS = os.environ.get("ENABLE_EXECUTING_LOGS", "1")
+
+VUL4J_COMMITS_URL = "https://github.com/tuhh-softsec/vul4j/commits/"

--- a/vul4j/main.py
+++ b/vul4j/main.py
@@ -196,7 +196,7 @@ class Vul4J:
         # copy to working directory
         copytree(BENCHMARK_PATH, output_dir, ignore=ignore_patterns('.git'))
 
-        cmd = "cd %s; git init; git add .; git commit -m \"init\"" % (
+        cmd = "cd %s; git init; git config user.name \"vul4j\"; git config user.email \"vul4j@vul4j.org\"; git add .; git commit -m \"init\"" % (
             output_dir)
         subprocess.call(cmd, shell=True, stdout=FNULL, stderr=subprocess.STDOUT)
 
@@ -209,7 +209,7 @@ class Vul4J:
         os.makedirs(os.path.join(output_dir, OUTPUT_FOLDER_NAME, "human_patch"))
         for file in vul['human_patch']:
             filename = file['file_path'].split("/")[-1]
-            shutil.copy(file['file_path'], os.path.join(output_dir, OUTPUT_FOLDER_NAME, "vulnerable", filename))
+            shutil.copy(os.path.join(output_dir, file['file_path']), os.path.join(output_dir, OUTPUT_FOLDER_NAME, "vulnerable", filename))
             with open(os.path.join(output_dir, OUTPUT_FOLDER_NAME, "human_patch", filename), "w",
                       encoding='utf-8') as f:
                 f.write(file['content'])

--- a/vul4j/main.py
+++ b/vul4j/main.py
@@ -42,6 +42,13 @@ def write_test_results_to_file(vul, test_results, revision):
                                         vul['project'].replace('-', '_'), vul['vul_id'].replace('-', '_'), revision))
     with (open(test_output_file, 'w', encoding='utf-8')) as f:
         f.write(test_results)
+        
+def get_commit_hash(commit_url: str):
+    commit_hash = commit_url.split("/")[-1]
+    if ".." in commit_hash:
+        return commit_hash.split("..")[-1].strip()
+    else:
+        return commit_hash.strip()
 
 
 class Vul4J:
@@ -67,7 +74,7 @@ class Vul4J:
                 src_classes_dir = row['src_classes'].strip()
                 test_classes_dir = row['test_classes'].strip()
                 human_patch_url = row['human_patch'].strip()
-                fixing_commit = human_patch_url[human_patch_url.rfind('/') + 1:]
+                fixing_commit = get_commit_hash(human_patch_url)
 
                 if failing_module != "root" and failing_module != "":
                     src_classes_dir = failing_module + '/' + src_classes_dir

--- a/vul4j/main.py
+++ b/vul4j/main.py
@@ -31,6 +31,10 @@ WORK_DIR = "/tmp/vul4j/reproduction"
 def extract_failed_tests_from_test_results(test_results):
     failing_tests = set()
     failures = test_results['tests']['failures']
+    passing_tests = test_results['tests']['passing_tests']
+    skipping_tests = test_results['tests']['skipping_tests']
+    if len(failures) == len(passing_tests) == len(skipping_tests) == 0:
+        return None # if all metrics are 0, then the build failed and no tests were run
     for failure in failures:
         failing_tests.add(failure['test_class'] + '#' + failure['test_method'])
     return failing_tests
@@ -612,7 +616,9 @@ def main_verify(args):
 
             failing_tests_of_vulnerable_revision = extract_failed_tests_from_test_results(test_results)
             logging.debug("Failing tests: %s" % failing_tests_of_vulnerable_revision)
-            if len(failing_tests_of_vulnerable_revision) == 0:
+            if failing_tests_of_vulnerable_revision is None:
+                logging.error("Build failed, no tests were run! This is acceptable here.")
+            elif len(failing_tests_of_vulnerable_revision) == 0:
                 logging.error("Vulnerable revision must contain at least 1 failing test!!!")
                 continue
 
@@ -638,7 +644,9 @@ def main_verify(args):
             test_results = json.loads(test_results_str)
 
             failing_tests_of_patched_revision = extract_failed_tests_from_test_results(test_results)
-            if len(failing_tests_of_patched_revision) != 0:
+            if failing_tests_of_patched_revision is None:
+                logging.error("Build failed, no tests were run! Human patch must compile and pass the tests!")
+            elif len(failing_tests_of_patched_revision) != 0:
                 logging.debug("Failing tests: %s" % failing_tests_of_patched_revision)
                 logging.error("Patched version must contain no failing test!!!")
                 continue
@@ -697,7 +705,9 @@ def main_reproduce(args):
 
             failing_tests_of_vulnerable_revision = extract_failed_tests_from_test_results(test_results)
             logging.debug("Failing tests: %s" % failing_tests_of_vulnerable_revision)
-            if len(failing_tests_of_vulnerable_revision) == 0:
+            if failing_tests_of_vulnerable_revision is None:
+                logging.error("Build failed, no tests were run! This is acceptable here.")
+            elif len(failing_tests_of_vulnerable_revision) == 0:
                 logging.error("Vulnerable revision must contain at least 1 failing test!!!")
                 continue
 
@@ -723,7 +733,9 @@ def main_reproduce(args):
             test_results = json.loads(test_results_str)
 
             failing_tests_of_patched_revision = extract_failed_tests_from_test_results(test_results)
-            if len(failing_tests_of_patched_revision) != 0:
+            if failing_tests_of_patched_revision is None:
+                logging.error("Build failed, no tests were run! Human patch must compile and pass the tests!")
+            elif len(failing_tests_of_patched_revision) != 0:
                 logging.debug("Failing tests: %s" % failing_tests_of_patched_revision)
                 logging.error("Patched version must contain no failing test!!!")
                 continue


### PR DESCRIPTION
### Added `apply` command

This command makes it easy to switch between and apply custom patches or code to the project. The different 'versions' are located in a project's VUL4J directory. Each version contains the files to be copied and a `paths.json` file which tells the script where to place the files. When checking out the project, the script creates two default versions for the vulnerable and patched code.

### Fix commit hash extraction

The dataset contains urls which compare two commits end like this: `hash..hash`. Somewhere in the script a git command failed to execute, and the extracted patch files remained empty. This is now fixed by extracting the last hash from the url.

**Fixes:** VUL4J-27 (partly), VUL4J-28

### Fix a bug when failed build is considered passing test

Some projects exit with build error when running tests. This results in the following report:
```
{
  "vul_id": "VUL4J-35",
  "cve_id": "CVE-2014-7809",
  "repository": {
    "name": "apache_struts",
    "url": "https://github.com/apache/struts",
    "human_patch_url": "https://github.com/apache/struts/commit/1f301038a751bf16e525607c3db513db835b2999"
  },
  "tests": {
    "overall_metrics": {
      "number_running": 0,
      "number_passing": 0,
      "number_error": 0,
      "number_failing": 0,
      "number_skipping": 0
    },
    "failures": [],
    "passing_tests": [],
    "skipping_tests": []
  }
```
In this case all tests were treated as passing. When running vulnerable tests, this event terminated the run. Now the script checks both the passing and skipping numbers.

**Fixes:** VUL4J-35 (partly), VUL4J-54

### Fix git init

The git init command failed because the user was not set. Now the repos are initialized with user `vul4j` and email `vul4j@vulj4.org`.

**Fixes:** VUL4J-64, VUL4J-65

### Update STATUS.md

### TODO

- Some fixes involve modifying other project files which need to stay untouched. Applying the human patch reverts these files back to original, breaking the project. Affected projects: VUL4J-23, VUL4J-67 (also VUL4J-27 but it works in that case)
- Some projects miss code lines in the human patch that are needed for testing. Affected projects: VUL4J-35, VUL4J-71