### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,13 @@ git clone https://github.com/bqcuong/vul4j
 python setup.py install
 ```
 
-3. Put your configuration information in the file `~/vul4j/vul4j.ini`:
+This will create a new `vul4j_data` folder in the home directory.
+If it already exists, you will need to manually delete it first.
+You can find the `vul4j.ini` and log files there.
+By default, the reproduction, temporary cloning and spotbugs directories are placed there as well.
+You can change these in the `vul4j.ini`.
+
+3. Put your configuration information in the file `~/vul4j_data/vul4j.ini`:
 ```ini
 JAVA7_HOME = <path-to-java-7-home-directory>
 JAVA8_HOME = <path-to-java-8-home-directory>
@@ -52,7 +58,10 @@ JAVA11_HOME = <path-to-java-11-home-directory>
 JAVA16_HOME = <path-to-java-16-home-directory>
 ```
 Other configuration values are optional,
-if left empty the environment variables will be checked or a default value will be used.
+if left empty, the environment variables will be checked or a default value will be used.
+
+The `vul4j.ini` within the **vul4j git repository** is just a sample
+and will get overridden by certain operations. Make sure to edit the one in your home directory.
 
 4. You can check if everything is installed correctly:
 ```shell

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 unidiff==0.7.0
 loguru
 command-builder
+GitPython

--- a/vul4j/main.py
+++ b/vul4j/main.py
@@ -43,7 +43,7 @@ def vul4j_checkout(args):
 @utils.log_frame("COMPILE")
 def vul4j_compile(args):
     try:
-        vul4j.build(args.outdir)
+        vul4j.build(args.outdir, clean=args.clean)
     except subprocess.CalledProcessError:
         raise RuntimeError("Compile failed!")
 
@@ -51,7 +51,7 @@ def vul4j_compile(args):
 @utils.log_frame("TEST")
 def vul4j_test(args):
     try:
-        vul4j.test(args.outdir, args.batchtype)
+        vul4j.test(args.outdir, args.batchtype, clean=args.clean)
     except subprocess.CalledProcessError:
         raise RuntimeError("Testing failed!")
 
@@ -139,6 +139,8 @@ def main(args=None):
                                             help="Compile the checked out vulnerability.")
     compile_parser.add_argument("-d", "--outdir", type=str,
                                 help="The directory to which the vulnerability was checked out.", required=True)
+    compile_parser.add_argument("-c", "--clean", action="store_true",
+                                help="Clean the project before compiling.")
     compile_parser.set_defaults(func=vul4j_compile)
 
     # TEST
@@ -148,6 +150,8 @@ def main(args=None):
                              help="The directory to which the vulnerability was checked out.", required=True)
     test_parser.add_argument("-b", "--batchtype", choices=["povs", "all"], default="all", type=str,
                              help="Two modes: all tests (all) by default, and only povs (povs).", required=False)
+    test_parser.add_argument("-c", "--clean", action="store_true",
+                             help="Clean the project before compiling.")
     test_parser.set_defaults(func=vul4j_test)
 
     # APPLY
@@ -199,9 +203,12 @@ def main(args=None):
     spotbugs_parser.set_defaults(func=get_spotbugs)
 
     options = parser.parse_args(args)
-    setup_logger(options.func.__name__.upper(), options.log, FILE_LOG_LEVEL)
 
-    if not hasattr(options, 'func'):
+    if hasattr(options, 'func'):
+        setup_logger(options.func.__name__.upper(), options.log, FILE_LOG_LEVEL)
+        if not utils.check_config():
+            exit(1)
+    else:
         parser.print_help()
         exit(1)
 


### PR DESCRIPTION
### Fix false test results on build error
When tests run successfully on a project, rerunning them – after modifying a file – may lead to a build failure, yet the results still appear as a successful run. This was because the previous test reports weren’t overridden in case of a build error. The reports are now deleted before running tests.

### Fix unexpected behaviour when target paths point to the vul4j git repository
Additional checks ensure that no folders or files can be placed inside the vul4j git repository.

### Other
- add force clean option to `vul4j compile` and `vul4j test`
- simplify some parts of the code
- minor fixes
